### PR TITLE
feat: 支持在Json中强制换行

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,16 @@
 				"command": "json-in-log.helloWorld",
 				"title": "Hello World"
 			}
-		]
+		],
+		"configuration": {
+			"properties": {
+				"json-in-log.forceWordWrap": {
+					"type": "boolean",
+					"default": false,
+					"description": "强制对json中的\\n进行换行"
+				}
+			}
+		}
 	},
 	"scripts": {
 		"vscode:prepublish": "yarn run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,16 @@ export function activate(context: vscode.ExtensionContext) {
 				if (<number>match.index >= character) {
 					return null;
 				}
+
 				try {
-					console.log(json);
+					console.log('json:', json);
 					const obj = JSON.parse(json);
-					const fmtJson = JSON.stringify(obj, null, 2);
+					let fmtJson = JSON.stringify(obj, null, 2);
+          const forceWrap = vscode.workspace.getConfiguration('json-in-log').get('forceWordWrap');
+          if (forceWrap) {
+            fmtJson = fmtJson.replace(/\\n/g, '\n');
+          }
+
 					return new vscode.Hover({
 						language: 'json',
 						value: fmtJson


### PR DESCRIPTION
JSON目前不支持\n换行，但是有相关的[feature request](https://github.com/microsoft/vscode/issues/89120)，插件现在采用的方法是将\n重新替换为换行符，会导致JSON的语法高亮有问题
fix #1 